### PR TITLE
:sparkles: configurable time entry types

### DIFF
--- a/harvest/README.md
+++ b/harvest/README.md
@@ -4,8 +4,9 @@ Downloads Harvest time entries for a given month. Classifies entries
 as IP Box applicable (or not!) and saves the detailed report to be used
 durign the audit. At the ends prints sum of IP Box hours per project.
 
-Classifier checks for time entry type of Development, so make sure they 
-are the ones that match IP Box rules!
+Classifier checks by default for time entry type of Development, so make sure they 
+are the ones that match IP Box rules! 
+You can overwrite default IP Box compatible time entry types by providing `--types` parameter.
 
 # Setup
 

--- a/harvest/main.py
+++ b/harvest/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import datetime
 import calendar
 from dataclasses import dataclass
 from collections import defaultdict
@@ -9,6 +8,7 @@ import os
 import csv
 
 import requests
+
 
 @dataclass
 class TimeEntry:
@@ -19,11 +19,14 @@ class TimeEntry:
     hours: float
 
 
-def matches_ipbox(time_entry: TimeEntry):
-    if time_entry.task == 'Development':
-        return True
-    return False
-    
+class IPBoxMatcher:
+
+    def __init__(self, task_types):
+        self._task_types = set(task_types)
+
+    def __call__(self, time_entry: TimeEntry):
+        return time_entry.task in self._task_types
+
 
 class HarvestAPI:
 
@@ -33,12 +36,12 @@ class HarvestAPI:
 
     def call_api(self, url, params):
         return requests.get(f'https://api.harvestapp.com/v2{url}',
-            params=params,
-            headers={
-                'Authorization':  f'Bearer {self.token}',
-                'Harvest-Account-Id': f'{self.account_id}',
-                'User-Agent': 'IP Box time entries scraper (https://github.com/szczeles/ip-box)'
-            }).json()
+                            params=params,
+                            headers={
+                                'Authorization':  f'Bearer {self.token}',
+                                'Harvest-Account-Id': f'{self.account_id}',
+                                'User-Agent': 'IP Box time entries scraper (https://github.com/szczeles/ip-box)'
+                            }).json()
 
     def iterate_time_entries(self, month):
         start_date = f'{month}-01'
@@ -47,12 +50,11 @@ class HarvestAPI:
         entries = []
         page = 1
         while page is not None:
-            response = self.call_api('/time_entries', 
-                {'from': start_date, 'to': end_date, 'page': page})
+            response = self.call_api('/time_entries', {'from': start_date, 'to': end_date, 'page': page})
             entries.extend(response['time_entries'])
             page = response['next_page']
 
-        for entry in sorted(entries, key=lambda entry: entry['spent_date']):
+        for entry in sorted(entries, key=lambda elem: elem['spent_date']):
             yield TimeEntry(
                 date=entry['spent_date'],
                 project=entry['project']['name'],
@@ -60,9 +62,10 @@ class HarvestAPI:
                 notes=entry['notes'],
                 hours=entry['hours']
             )
-        
+
+
 class ReportWriter:
-    def __init__(self, filepath):
+    def __init__(self, filepath, ipbox_matcher):
         self.file = open(filepath, 'w+')
         self.writer = csv.writer(self.file)
         self.writer.writerow([
@@ -72,6 +75,7 @@ class ReportWriter:
             'hours',
             'ip_box_applicable'
         ])
+        self._ipbox_matcher = ipbox_matcher
 
     def write(self, entry):
         self.writer.writerow([
@@ -79,7 +83,7 @@ class ReportWriter:
             entry.task,
             entry.notes,
             entry.hours,
-            matches_ipbox(entry)
+            self._ipbox_matcher(entry)
         ])
 
     def close(self):
@@ -87,19 +91,20 @@ class ReportWriter:
         
 
 class MultiProjectReportWriter:
-    def __init__(self, base_path):
+    def __init__(self, base_path, ipbox_matcher):
         self.base_path = base_path
         self.writers = {}
         self.ipbox_hours = defaultdict(float)
+        self._ipbox_matcher = ipbox_matcher
 
     def get_path(self, project):
         return f'{self.base_path}/Harvest {project}.csv'
 
     def write(self, entry):
         if not entry.project in self.writers:
-            self.writers[entry.project] = ReportWriter(self.get_path(entry.project))
+            self.writers[entry.project] = ReportWriter(self.get_path(entry.project), self._ipbox_matcher)
         self.writers[entry.project].write(entry)
-        if matches_ipbox(entry):
+        if self._ipbox_matcher(entry):
             self.ipbox_hours[entry.project] += entry.hours
 
     def __enter__(self):
@@ -111,17 +116,21 @@ class MultiProjectReportWriter:
             self.writers[project].close()
         return True
 
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--account', help='Account ID', required=True)
     parser.add_argument('--token', help='Personal token', required=True)
     parser.add_argument('--month', help='YYYY-MM format', required=True)
     parser.add_argument('--path', help='Reports path', required=True)
+    parser.add_argument('--types', help='Time entry types considered as IP Box compatible',
+                        nargs='+', required=False, default=['Development'])
     args = parser.parse_args()
 
     api = HarvestAPI(args.account, args.token)
     os.makedirs(f'{args.path}/{args.month}', exist_ok=True)
-    with MultiProjectReportWriter(f'{args.path}/{args.month}') as writer:
+    ipbox_matcher = IPBoxMatcher(args.types)
+    with MultiProjectReportWriter(f'{args.path}/{args.month}', ipbox_matcher) as writer:
         for time_entry in api.iterate_time_entries(args.month):
             writer.write(time_entry)
 


### PR DESCRIPTION
I needed to specify the custom Harvest Time Entry type (other than Development) for my IP Box documentation, so I've extended your reports with an additional flag. Change should be backward compatible. I hope it will help somebody.